### PR TITLE
fixup! compose: Print progress during ostree commit

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -906,8 +906,6 @@ rpmostree_compose_builtin_tree (int             argc,
                            &rootfs_fd, error))
         goto out;
 
-      g_print ("Committing...\n");
-      
       if (!rpmostree_commit (rootfs_fd, repo, self->ref, metadata, gpgkey, selinux, NULL,
                              &new_revision,
                              cancellable, error))

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1807,6 +1807,8 @@ rpmostree_commit (int            rootfs_fd,
 
     while (g_atomic_int_get (&tdata.done) == 0)
       g_main_context_iteration (NULL, TRUE);
+
+    glnx_console_progress_text_percent ("Committing:", 100.0);
   
     glnx_console_unlock (&console);
     

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1591,13 +1591,28 @@ rpmostree_prepare_rootfs_for_commit (GFile         *rootfs,
   return ret;
 }
 
+struct CommitThreadData {
+  volatile gint done;
+  guint n_files;
+  volatile gint n_processed;
+  OstreeRepo *repo;
+  int rootfs_fd;
+  OstreeMutableTree *mtree;
+  OstreeSePolicy *sepolicy;
+  OstreeRepoCommitModifier *commit_modifier;
+  gboolean success;
+  GCancellable *cancellable;
+  GError **error;
+};
+
 static GVariant *
 read_xattrs_cb (OstreeRepo     *repo,
                 const char     *relpath,
                 GFileInfo      *file_info,
                 gpointer        user_data)
 {
-  int rootfs_fd = GPOINTER_TO_INT (user_data);
+  struct CommitThreadData *tdata = user_data;
+  int rootfs_fd = tdata->rootfs_fd;
   /* Hardcoded at the moment, we're only taking file caps */
   static const char *accepted_xattrs[] = { "security.capability" };
   guint i;
@@ -1625,6 +1640,9 @@ read_xattrs_cb (OstreeRepo     *repo,
         goto out;
     }
 
+  if (g_file_info_get_file_type (file_info) != G_FILE_TYPE_DIRECTORY)
+    g_atomic_int_inc (&tdata->n_processed);
+
   viter = g_variant_iter_new (existing_xattrs);
 
   while (g_variant_iter_loop (viter, "(@ay@ay)", &key, &value))
@@ -1650,6 +1668,69 @@ read_xattrs_cb (OstreeRepo     *repo,
   return g_variant_ref_sink (g_variant_builder_end (&builder));
 }
 
+static gboolean
+count_files (int dfd,
+             const char *path,
+             guint *out_n_files,
+             GCancellable *cancellable,
+             GError **error)
+{
+  g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+  
+  if (!glnx_dirfd_iterator_init_at (dfd, path, TRUE, &dfd_iter, error))
+    return FALSE;
+  
+  while (TRUE)
+    {
+      struct dirent *dent = NULL;
+
+      if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent, cancellable, error))
+        return FALSE;
+      if (!dent)
+        break;
+
+      if (dent->d_type == DT_DIR)
+        {
+          if (!count_files (dfd_iter.fd, dent->d_name, out_n_files,
+                            cancellable, error))
+            return FALSE;
+        }
+      else
+        (*out_n_files)++;
+    }
+
+  return TRUE;
+}
+
+static gpointer
+write_dfd_thread (gpointer datap)
+{
+  struct CommitThreadData *data = datap;
+
+  if (!ostree_repo_write_dfd_to_mtree (data->repo, data->rootfs_fd, ".",
+                                       data->mtree,
+                                       data->commit_modifier,
+                                       data->cancellable, data->error))
+    goto out;
+  
+  data->success = TRUE;
+ out:
+  g_atomic_int_inc (&data->done);
+  g_main_context_wakeup (NULL);
+  return NULL;
+}
+
+static gboolean
+on_progress_timeout (gpointer datap)
+{
+  struct CommitThreadData *data = datap;
+  const int n_processed = g_atomic_int_get (&data->n_processed);
+
+  glnx_console_progress_text_percent ("Committing:", (100.0*n_processed)/data->n_files);
+
+  return TRUE;
+}
+
 gboolean
 rpmostree_commit (int            rootfs_fd,
                   OstreeRepo    *repo,
@@ -1664,6 +1745,8 @@ rpmostree_commit (int            rootfs_fd,
 {
   gboolean ret = FALSE;
   OstreeRepoTransactionStats stats = { 0, };
+  guint n_files = 0;
+  struct CommitThreadData tdata = { 0, };
   glnx_unref_object OstreeMutableTree *mtree = NULL;
   OstreeRepoCommitModifier *commit_modifier = NULL;
   g_autofree char *parent_revision = NULL;
@@ -1685,7 +1768,7 @@ rpmostree_commit (int            rootfs_fd,
   commit_modifier = ostree_repo_commit_modifier_new (0, NULL, NULL, NULL);
   ostree_repo_commit_modifier_set_xattr_callback (commit_modifier,
                                                   read_xattrs_cb, NULL,
-                                                  GINT_TO_POINTER (rootfs_fd));
+                                                  &tdata);
 
   if (sepolicy && ostree_sepolicy_get_name (sepolicy) != NULL)
     ostree_repo_commit_modifier_set_sepolicy (commit_modifier, sepolicy);
@@ -1699,8 +1782,41 @@ rpmostree_commit (int            rootfs_fd,
   if (devino_cache)
     ostree_repo_commit_modifier_set_devino_cache (commit_modifier, devino_cache);
 
-  if (!ostree_repo_write_dfd_to_mtree (repo, rootfs_fd, ".", mtree, commit_modifier, cancellable, error))
+  if (!count_files (rootfs_fd, ".", &n_files, cancellable, error))
     goto out;
+
+  tdata.n_files = n_files;
+  tdata.repo = repo;
+  tdata.rootfs_fd = rootfs_fd;
+  tdata.mtree = mtree;
+  tdata.sepolicy = sepolicy;
+  tdata.commit_modifier = commit_modifier;
+  tdata.error = error;
+
+  { g_autoptr(GThread) commit_thread = NULL;
+    g_auto(GLnxConsoleRef) console = { 0, };
+    g_autoptr(GSource) progress_src = NULL;
+
+    glnx_console_lock (&console);
+
+    commit_thread = g_thread_new ("commit", write_dfd_thread, &tdata);
+
+    progress_src = g_timeout_source_new_seconds (console.is_tty ? 1 : 5);
+    g_source_set_callback (progress_src, on_progress_timeout, &tdata, NULL);
+    g_source_attach (progress_src, NULL);
+
+    while (g_atomic_int_get (&tdata.done) == 0)
+      g_main_context_iteration (NULL, TRUE);
+  
+    glnx_console_unlock (&console);
+    
+    g_thread_join (commit_thread);
+    commit_thread = NULL;
+
+    if (!tdata.success)
+      goto out;
+  }
+
   if (!ostree_repo_write_mtree (repo, mtree, &root_tree, cancellable, error))
     goto out;
 

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1593,8 +1593,9 @@ rpmostree_prepare_rootfs_for_commit (GFile         *rootfs,
 
 struct CommitThreadData {
   volatile gint done;
-  guint n_files;
-  volatile gint n_processed;
+  off_t n_bytes;
+  off_t n_processed;
+  volatile gint percent;
   OstreeRepo *repo;
   int rootfs_fd;
   OstreeMutableTree *mtree;
@@ -1641,7 +1642,10 @@ read_xattrs_cb (OstreeRepo     *repo,
     }
 
   if (g_file_info_get_file_type (file_info) != G_FILE_TYPE_DIRECTORY)
-    g_atomic_int_inc (&tdata->n_processed);
+    {
+      tdata->n_processed += g_file_info_get_size (file_info);
+      g_atomic_int_set (&tdata->percent, (gint)((100.0*tdata->n_processed)/tdata->n_bytes));
+    }
 
   viter = g_variant_iter_new (existing_xattrs);
 
@@ -1669,11 +1673,11 @@ read_xattrs_cb (OstreeRepo     *repo,
 }
 
 static gboolean
-count_files (int dfd,
-             const char *path,
-             guint *out_n_files,
-             GCancellable *cancellable,
-             GError **error)
+count_filesizes (int dfd,
+                 const char *path,
+                 off_t *out_n_bytes,
+                 GCancellable *cancellable,
+                 GError **error)
 {
   g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
   
@@ -1691,12 +1695,22 @@ count_files (int dfd,
 
       if (dent->d_type == DT_DIR)
         {
-          if (!count_files (dfd_iter.fd, dent->d_name, out_n_files,
-                            cancellable, error))
+          if (!count_filesizes (dfd_iter.fd, dent->d_name, out_n_bytes,
+                                cancellable, error))
             return FALSE;
         }
       else
-        (*out_n_files)++;
+        {
+          struct stat stbuf;
+
+          if (fstatat (dfd_iter.fd, dent->d_name, &stbuf, AT_SYMLINK_NOFOLLOW) != 0)
+            {
+              glnx_set_prefix_error_from_errno (error, "%s", "fstatat");
+              return FALSE;
+            }
+
+          (*out_n_bytes) += stbuf.st_size;
+        }
     }
 
   return TRUE;
@@ -1712,7 +1726,7 @@ write_dfd_thread (gpointer datap)
                                        data->commit_modifier,
                                        data->cancellable, data->error))
     goto out;
-  
+
   data->success = TRUE;
  out:
   g_atomic_int_inc (&data->done);
@@ -1724,9 +1738,9 @@ static gboolean
 on_progress_timeout (gpointer datap)
 {
   struct CommitThreadData *data = datap;
-  const int n_processed = g_atomic_int_get (&data->n_processed);
+  const gint percent = g_atomic_int_get (&data->percent);
 
-  glnx_console_progress_text_percent ("Committing:", (100.0*n_processed)/data->n_files);
+  glnx_console_progress_text_percent ("Committing:", percent);
 
   return TRUE;
 }
@@ -1745,7 +1759,7 @@ rpmostree_commit (int            rootfs_fd,
 {
   gboolean ret = FALSE;
   OstreeRepoTransactionStats stats = { 0, };
-  guint n_files = 0;
+  off_t n_bytes = 0;
   struct CommitThreadData tdata = { 0, };
   glnx_unref_object OstreeMutableTree *mtree = NULL;
   OstreeRepoCommitModifier *commit_modifier = NULL;
@@ -1782,10 +1796,10 @@ rpmostree_commit (int            rootfs_fd,
   if (devino_cache)
     ostree_repo_commit_modifier_set_devino_cache (commit_modifier, devino_cache);
 
-  if (!count_files (rootfs_fd, ".", &n_files, cancellable, error))
+  if (!count_filesizes (rootfs_fd, ".", &n_bytes, cancellable, error))
     goto out;
 
-  tdata.n_files = n_files;
+  tdata.n_bytes = n_bytes;
   tdata.repo = repo;
   tdata.rootfs_fd = rootfs_fd;
   tdata.mtree = mtree;

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1663,6 +1663,7 @@ rpmostree_commit (int            rootfs_fd,
                   GError       **error)
 {
   gboolean ret = FALSE;
+  OstreeRepoTransactionStats stats = { 0, };
   glnx_unref_object OstreeMutableTree *mtree = NULL;
   OstreeRepoCommitModifier *commit_modifier = NULL;
   g_autofree char *parent_revision = NULL;
@@ -1724,8 +1725,14 @@ rpmostree_commit (int            rootfs_fd,
   if (refname)
     ostree_repo_transaction_set_ref (repo, NULL, refname, new_revision);
 
-  if (!ostree_repo_commit_transaction (repo, NULL, cancellable, error))
+  if (!ostree_repo_commit_transaction (repo, &stats, cancellable, error))
     goto out;
+
+  g_print ("Metadata Total: %u\n", stats.metadata_objects_total);
+  g_print ("Metadata Written: %u\n", stats.metadata_objects_written);
+  g_print ("Content Total: %u\n", stats.content_objects_total);
+  g_print ("Content Written: %u\n", stats.content_objects_written);
+  g_print ("Content Bytes Written: %" G_GUINT64_FORMAT "\n", stats.content_bytes_written);
 
   ret = TRUE;
   if (out_new_revision)


### PR DESCRIPTION
Use file size instead of file count for a smoother & more accurate progress bar. I measured the stat penalty to be about ~60 ms. Up to you of course if you want it esp. since it's all going to change soon, just thought it was an easy way to improve things :)